### PR TITLE
feat: add normalized VLA tab with verified seed models

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -377,6 +377,42 @@ body {
   font-size: 12px;
 }
 
+.vla-placeholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 24px;
+  text-align: center;
+}
+
+.vla-placeholder__eyebrow {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.vla-placeholder__title {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 28px;
+  letter-spacing: 4px;
+  text-transform: uppercase;
+  color: var(--text);
+}
+
+.vla-placeholder__meta {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 1px;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+}
+
 .component-info {
   padding: 32px;
   display: flex;
@@ -577,6 +613,14 @@ body {
   font-size: 18px;
   color: var(--text-dim);
   margin-top: 32px;
+}
+
+.chain-empty {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 1px;
+  color: var(--text-dim);
+  padding: 10px 0;
 }
 
 /* OEM Grid */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useEffect, useCallback, useRef } from 'react';
 import PLYViewer, { preloadPLY } from './components/PLYViewer';
 import SupplyChainGraph from './components/SupplyChainGraph';
-import { companies, relationships, componentCategories } from './data';
+import { companies, relationships, componentCategories, vlaModels } from './data';
 import './App.css';
 
 // Start fetching the skeleton model immediately on module load
@@ -15,6 +15,7 @@ const TABS = [
   { id: 'timeline', label: 'Buildout' },
   { id: 'sensors_general', label: 'Sensors' },
   { id: 'compute', label: 'Compute' },
+  { id: 'vlas', label: 'VLA' },
   { id: 'batteries', label: 'Battery' },
   { id: 'motors', label: 'Motors' },
   { id: 'reducers', label: 'Reducers' },
@@ -396,6 +397,41 @@ function getComponentChain(componentId: string) {
     oems: oemIds.map((id) => companies.find((c) => c.id === id)).filter(Boolean),
     rels,
     upstreamRels,
+  };
+}
+
+function getCompanyVlaLinks(companyId: string) {
+  return vlaModels.flatMap((model) =>
+    model.companyLinks
+      .filter((link) => link.companyId === companyId)
+      .map((link) => ({ model, link }))
+  );
+}
+
+function getVlaRelationshipTypeLabel(type: 'proprietary' | 'partner' | 'open' | 'ecosystem') {
+  if (type === 'proprietary') return 'Proprietary / In-House';
+  if (type === 'partner') return 'Partner Integration';
+  if (type === 'open') return 'Open Model';
+  return 'Standalone Ecosystem Model';
+}
+
+function getVlaCompanyRelationshipLabel(type: 'proprietary' | 'partner') {
+  if (type === 'proprietary') return 'Proprietary / In-House';
+  return 'Partner Integration';
+}
+
+function getVLAOverview() {
+  const linkedOemIds = new Set(
+    vlaModels.flatMap((model) => model.companyLinks.map((link) => link.companyId))
+  );
+  const creatorCount = new Set(vlaModels.map((model) => model.developer)).size;
+  const standaloneModels = vlaModels.filter((model) => model.companyLinks.length === 0).length;
+
+  return {
+    trackedModels: vlaModels.length,
+    linkedOems: linkedOemIds.size,
+    creatorCount,
+    standaloneModels,
   };
 }
 
@@ -824,13 +860,38 @@ export default function App() {
     [companyId]
   );
 
+  const linkedCompanyVlaModels = useMemo(
+    () => (selectedCompany ? getCompanyVlaLinks(selectedCompany.id) : []),
+    [selectedCompany]
+  );
+
   const chain = useMemo(() => {
     if (activeTab === 'skeleton' || activeTab === 'all_oems' || activeTab === 'geopolitics') return null;
+    if (activeTab === 'vlas') return null;
     if (activeTab === 'actuators_rotary') {
       return getComponentChain(actuatorType === 'linear' ? 'actuators_linear_only' : 'actuators_rotary_only');
     }
     return getComponentChain(activeTab);
   }, [activeTab, actuatorType]);
+
+  const vlaOverview = useMemo(() => getVLAOverview(), []);
+
+  const focusedVlaModel = useMemo(
+    () => vlaModels.find((model) => model.id === chainFocus) || null,
+    [chainFocus]
+  );
+
+  const focusedVlaOemIds = useMemo(
+    () => new Set(focusedVlaModel?.companyLinks.map((link) => link.companyId) || []),
+    [focusedVlaModel]
+  );
+
+  const linkedVlaOems = useMemo(() => {
+    const ids = [...new Set(vlaModels.flatMap((model) => model.companyLinks.map((link) => link.companyId)))];
+    return ids
+      .map((id) => companies.find((company) => company.id === id))
+      .filter(Boolean) as typeof companies;
+  }, []);
 
   // Compute which entities are connected to the focused entity in the chain
   const connectedIds = useMemo(() => {
@@ -1280,6 +1341,13 @@ export default function App() {
                 <Spec label="Battery" value={specs.battery} />
                 <Spec label="Charging" value={specs.charging} />
                 <Spec label="AI Partner" value={specs.aiPartner} />
+                <Spec
+                  label="In-House VLA Model"
+                  value={linkedCompanyVlaModels
+                    .filter(({ link }) => link.relationship === 'proprietary')
+                    .map(({ model }) => model.name)
+                    .join(', ')}
+                />
                 <Spec label="Software" value={specs.software} />
                 <Spec label="Data Collection" value={specs.dataCollection} />
                 {specs.bom && <Spec label="BOM" value={specs.bom} />}
@@ -2040,6 +2108,20 @@ export default function App() {
                       </button>
                     </div>
                   </>
+                ) : activeTab === 'vlas' ? (
+                  <div className="vla-placeholder">
+                    <span className="vla-placeholder__eyebrow">
+                      {focusedVlaModel ? focusedVlaModel.developer : 'Vision-Language-Action'}
+                    </span>
+                    <span className="vla-placeholder__title">
+                      {focusedVlaModel ? focusedVlaModel.name : 'VLA'}
+                    </span>
+                    <span className="vla-placeholder__meta">
+                      {focusedVlaModel
+                        ? `${focusedVlaModel.country} · ${focusedVlaModel.release} · ${focusedVlaModel.availability}`
+                        : `${vlaOverview.trackedModels} tracked models · ${vlaOverview.linkedOems} linked humanoid OEMs`}
+                    </span>
+                  </div>
                 ) : selectedComponent.plyModel ? (
                   <PLYViewer modelUrl={selectedComponent.plyModel} color="#1a1a1a" initialRotation={MODEL_ROTATIONS[selectedComponent.plyModel]} spinSpeed={MODEL_SPIN[selectedComponent.plyModel]} scale={MODEL_SCALE[selectedComponent.plyModel]} />
                 ) : (
@@ -2050,8 +2132,39 @@ export default function App() {
               <div className="component-info">
                 {(() => {
                   const isActuator = activeTab === 'actuators_rotary';
-                  const desc = isActuator ? ACTUATOR_INFO[actuatorType].description : selectedComponent.description;
-                  const metrics = isActuator ? ACTUATOR_INFO[actuatorType].keyMetrics : selectedComponent.keyMetrics;
+                  const desc = isActuator
+                    ? ACTUATOR_INFO[actuatorType].description
+                    : activeTab === 'vlas' && focusedVlaModel
+                      ? focusedVlaModel.description
+                      : selectedComponent.description;
+                  const metrics = isActuator
+                    ? ACTUATOR_INFO[actuatorType].keyMetrics
+                    : activeTab === 'vlas'
+                      ? focusedVlaModel
+                        ? {
+                            Developer: focusedVlaModel.developer,
+                            'Relationship Type': getVlaRelationshipTypeLabel(focusedVlaModel.relationshipType),
+                            Release: focusedVlaModel.release,
+                            Availability: focusedVlaModel.availability,
+                            Focus: focusedVlaModel.focus,
+                            'Linked OEMs': focusedVlaModel.companyLinks.length
+                              ? focusedVlaModel.companyLinks
+                                  .map((link) => {
+                                    const company = companies.find((candidate) => candidate.id === link.companyId);
+                                    return company ? `${company.name} (${getVlaCompanyRelationshipLabel(link.relationship)})` : null;
+                                  })
+                                  .filter(Boolean)
+                                  .join(', ')
+                              : 'None tracked in current dataset',
+                            Sources: focusedVlaModel.sources.map((source) => source.label).join(' · '),
+                          }
+                        : {
+                            'Tracked Models': String(vlaOverview.trackedModels),
+                            'Linked OEMs': String(vlaOverview.linkedOems),
+                            'Model Developers': String(vlaOverview.creatorCount),
+                            'Standalone Models': String(vlaOverview.standaloneModels),
+                          }
+                      : selectedComponent.keyMetrics;
 
                   return (
                     <>
@@ -2082,6 +2195,65 @@ export default function App() {
                 })()}
               </div>
             </div>
+
+            {activeTab === 'vlas' && (
+              <div className="supply-chain">
+                <div className="supply-chain__header">
+                  <h3 className="section-title">Model Ecosystem</h3>
+                  {focusedVlaModel && (
+                    <button className="chain-clear" onClick={() => setChainFocus(null)}>
+                      Clear filter
+                    </button>
+                  )}
+                </div>
+                <div className="chain-flow">
+                  <div className="chain-tier">
+                    <div className="chain-tier-label">Models</div>
+                    {vlaModels.map((model) => (
+                      <button
+                        key={model.id}
+                        className={`chain-entity ${focusedVlaModel && focusedVlaModel.id !== model.id ? 'chain-entity--dim' : ''} ${focusedVlaModel?.id === model.id ? 'chain-entity--focused' : ''} ${countryFilter && getCountryGroup(model.country) !== countryFilter ? 'geo-dim' : ''}`}
+                        onClick={() => setChainFocus((prev) => prev === model.id ? null : model.id)}
+                      >
+                        <span className="chain-name">{model.name}</span>
+                        <span className="chain-country">{model.country}</span>
+                        <span className="chain-share">
+                          {model.developer} · {getVlaRelationshipTypeLabel(model.relationshipType)}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                  <div className="chain-arrow">&rarr;</div>
+                  <div className="chain-tier">
+                    <div className="chain-tier-label">Linked OEMs</div>
+                    {linkedVlaOems.length > 0 ? linkedVlaOems.map((company) => (
+                      <button
+                        key={company.id}
+                        className={`chain-entity ${focusedVlaModel && !focusedVlaOemIds.has(company.id) ? 'chain-entity--dim' : ''} ${countryFilter && getCountryGroup(company.country) !== countryFilter ? 'geo-dim' : ''}`}
+                        onClick={() => handleSelectCompany(company.id)}
+                      >
+                        <span className="chain-name">{company.name}</span>
+                        <span className="chain-country">{company.country}</span>
+                        <span className="chain-share">
+                          {(focusedVlaModel
+                            ? getCompanyVlaLinks(company.id)
+                                .filter(({ model }) => model.id === focusedVlaModel.id)
+                                .map(({ link }) => getVlaCompanyRelationshipLabel(link.relationship))
+                            : getCompanyVlaLinks(company.id)
+                                .map(({ model, link }) => `${model.name} (${getVlaCompanyRelationshipLabel(link.relationship)})`)
+                          ).join(', ')}
+                        </span>
+                      </button>
+                    )) : (
+                      <div className="chain-empty">No linked humanoid OEMs tracked yet.</div>
+                    )}
+                    {focusedVlaModel && focusedVlaModel.companyLinks.length === 0 && (
+                      <div className="chain-empty">No humanoid OEM relationship tracked for {focusedVlaModel.name} in the current dataset.</div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            )}
 
             {chain && (chain.upstream.length > 0 || chain.suppliers.length > 0 || chain.oems.length > 0) && (
               <div className="supply-chain">

--- a/src/data/components.ts
+++ b/src/data/components.ts
@@ -123,6 +123,18 @@ export const componentCategories: ComponentCategory[] = [
     },
   },
   {
+    id: 'vlas',
+    name: 'VLA Models',
+    description: 'Vision-language-action models sit above the robot stack as the generalist reasoning and action layer. They unify perception, language grounding, and control policies for embodied tasks.',
+    bottleneck: false,
+    keyMetrics: {
+      'Core Modalities': 'Vision + Language + Action',
+      'Primary Role': 'Task planning + embodied control',
+      'Deployment Pattern': 'Partner access, internal stacks, model platforms',
+      'Current Focus': 'Generalist manipulation and robot reasoning',
+    },
+  },
+  {
     id: 'pcbs',
     name: 'PCBs',
     description: 'Printed circuit boards for power distribution, sensor integration, and compute interconnects.',

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,4 +1,5 @@
 export { companies } from './companies';
 export { relationships } from './relationships';
 export { componentCategories } from './components';
-export type { Company, SupplyRelationship, ComponentCategory, RobotSpecs, EntityType, Country } from './types';
+export { vlaModels } from './vlaModels';
+export type { Company, SupplyRelationship, ComponentCategory, RobotSpecs, EntityType, Country, VLAModel } from './types';

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -69,3 +69,35 @@ export interface ComponentCategory {
   bottleneckReason?: string;
   keyMetrics?: Record<string, string>;
 }
+
+export interface VLASourceRef {
+  label: string;
+  url: string;
+}
+
+export type VLAEntryRelationshipType = 'proprietary' | 'partner' | 'open' | 'ecosystem';
+export type VLACompanyRelationshipType = 'proprietary' | 'partner';
+
+export interface VLACompanyLink {
+  companyId: string;
+  relationship: VLACompanyRelationshipType;
+  sources: VLASourceRef[];
+  ambiguous?: boolean;
+  ambiguityNote?: string;
+}
+
+export interface VLAModel {
+  id: string;
+  name: string;
+  developer: string;
+  country: Country;
+  relationshipType: VLAEntryRelationshipType;
+  description: string;
+  release: string;
+  focus: string;
+  availability: string;
+  sources: VLASourceRef[];
+  ambiguous?: boolean;
+  ambiguityNote?: string;
+  companyLinks: VLACompanyLink[];
+}

--- a/src/data/vlaModels.ts
+++ b/src/data/vlaModels.ts
@@ -1,0 +1,123 @@
+import type { VLAModel } from './types';
+
+export const vlaModels: VLAModel[] = [
+  {
+    id: 'helix_02',
+    name: 'Helix 02',
+    developer: 'Figure',
+    country: 'US',
+    relationshipType: 'proprietary',
+    description: 'Figure\'s latest Helix model for high-rate, full-upper-body control and long-horizon object handling on its humanoid platform.',
+    release: '2026',
+    focus: 'Whole-body humanoid manipulation',
+    availability: 'Internal / Figure-only',
+    sources: [
+      { label: 'Figure: Helix 02', url: 'https://www.figure.ai/news/helix-02' },
+      { label: 'Figure: Helix', url: 'https://www.figure.ai/news/helix' },
+    ],
+    companyLinks: [
+      {
+        companyId: 'figure',
+        relationship: 'proprietary',
+        sources: [
+          { label: 'Figure: Helix 02', url: 'https://www.figure.ai/news/helix-02' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'redwood_ai',
+    name: 'Redwood AI',
+    developer: '1X',
+    country: 'US',
+    relationshipType: 'proprietary',
+    description: '1X\'s Redwood AI is its in-house robot intelligence stack for NEO, aimed at end-to-end mobile manipulation in home environments.',
+    release: '2025',
+    focus: 'End-to-end mobile manipulation',
+    availability: 'Internal / 1X-only',
+    sources: [
+      { label: '1X: Redwood AI', url: 'https://www.1x.tech/discover/redwood-ai' },
+    ],
+    companyLinks: [
+      {
+        companyId: '1x',
+        relationship: 'proprietary',
+        sources: [
+          { label: '1X: Redwood AI', url: 'https://www.1x.tech/discover/redwood-ai' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'gemini_robotics',
+    name: 'Gemini Robotics',
+    developer: 'Google DeepMind',
+    country: 'US',
+    relationshipType: 'partner',
+    description: 'Google DeepMind\'s robotics model family that extends Gemini into embodied reasoning and robot action.',
+    release: '2025',
+    focus: 'Embodied reasoning + robot action',
+    availability: 'Partner access',
+    sources: [
+      { label: 'DeepMind: Gemini Robotics', url: 'https://deepmind.google/models/gemini-robotics/' },
+      { label: 'Apptronik + Google DeepMind', url: 'https://apptronik.com/news-collection/apptronik-partners-with-google-deepmind-robotics' },
+    ],
+    companyLinks: [
+      {
+        companyId: 'apptronik',
+        relationship: 'partner',
+        sources: [
+          { label: 'DeepMind: Gemini Robotics', url: 'https://deepmind.google/models/gemini-robotics/' },
+          { label: 'Apptronik + Google DeepMind', url: 'https://apptronik.com/news-collection/apptronik-partners-with-google-deepmind-robotics' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'groot_n1',
+    name: 'GR00T N1',
+    developer: 'NVIDIA',
+    country: 'US',
+    relationshipType: 'open',
+    description: 'NVIDIA\'s open humanoid foundation model and post-training stack for customizable humanoid reasoning and skills.',
+    release: '2025',
+    focus: 'Open humanoid foundation model',
+    availability: 'Open / customizable',
+    sources: [
+      { label: 'NVIDIA News: GR00T N1', url: 'https://nvidianews.nvidia.com/news/nvidia-isaac-gr00t-n1-open-humanoid-robot-foundation-model-simulation-frameworks' },
+      { label: 'NVIDIA Research: GR00T N1', url: 'https://research.nvidia.com/publication/2025-03_nvidia-isaac-gr00t-n1-open-foundation-model-humanoid-robots' },
+    ],
+    companyLinks: [],
+  },
+  {
+    id: 'skild_brain',
+    name: 'Skild Brain',
+    developer: 'Skild AI',
+    country: 'US',
+    relationshipType: 'ecosystem',
+    description: 'Skild AI\'s omni-bodied robotics foundation model designed to generalize across robot types and tasks.',
+    release: '2024',
+    focus: 'General-purpose robotics intelligence',
+    availability: 'Platform / enterprise access',
+    sources: [
+      { label: 'Skild AI: Homepage', url: 'https://www.skild.ai/' },
+      { label: 'Skild AI: Robotic Brain', url: 'https://www.skild.ai/blogs/building-the-general-purpose-robotic-brain' },
+    ],
+    companyLinks: [],
+  },
+  {
+    id: 'pi0',
+    name: 'pi0',
+    developer: 'Physical Intelligence',
+    country: 'US',
+    relationshipType: 'ecosystem',
+    description: 'Physical Intelligence\'s first generalist robotic policy for broad task execution, now available through the openpi release.',
+    release: '2024',
+    focus: 'Generalist robot policy',
+    availability: 'Open weights / code',
+    sources: [
+      { label: 'Physical Intelligence: openpi', url: 'https://www.physicalintelligence.company/blog/openpi' },
+    ],
+    companyLinks: [],
+  },
+];


### PR DESCRIPTION
## Summary

This PR adds a focused first-pass VLA tab to Humanoid Atlas and normalizes how VLA model relationships are represented in both the data model and UI.

This is intentionally a normalization + feature pass, not a market expansion pass.

## What this adds

- A new `VLA` tab in the main app navigation
- A small, high-signal seeded VLA dataset
- Normalized relationship semantics for VLA entries
- UI labeling that distinguishes:
  - proprietary / in-house
  - partner integration
  - open model
  - standalone ecosystem model

## What this changes

### 1. New VLA tab
Adds a new top-level tab for VLA models using the existing component-style screen structure.

### 2. Normalized VLA schema
Introduces a schema that can represent:
- top-level model relationship type
- OEM-specific links only when officially supported
- source references
- ambiguity support for future use

### 3. Corrected verified seed set
Keeps the initial dataset intentionally small and source-backed:
- Figure → Helix 02
- 1X → Redwood AI
- NVIDIA → GR00T N1
- Apptronik ↔ Gemini Robotics
- Skild AI → Skild Brain
- Physical Intelligence → pi0

### 4. Correct relationship semantics in the UI
Partner or open models are no longer presented as if they are owned by the OEM.

Only proprietary / in-house relationships appear as OEM-owned models on company pages.

## Why this matters

Before this pass, the VLA layer risked conflating:
- proprietary models
- partner integrations
- open models
- broader ecosystem models

This PR makes those distinctions explicit so the product can grow this area without accumulating semantic drift.

## Scope notes

This PR does **not** expand VLA market coverage beyond the initial seed set.

The scope is intentionally limited to:
- VLA tab introduction
- verified seed normalization
- relationship-schema cleanup
- UI labeling cleanup

## Verification

- `pnpm build` passes

## Branch / commit

- Branch: `codex/vla-tab`
- Commit: `6a3ec451c899bc318c380336409aaed06263a9e0`