### PR TITLE
fix: correct UBTECH ticker from UBXG.HK to 9880.HK

### DIFF
--- a/src/data/companies.ts
+++ b/src/data/companies.ts
@@ -549,8 +549,8 @@ export const companies: Company[] = [
     name: 'UBTECH (Walker S2)',
     type: 'oem',
     country: 'CN',
-    description: 'One of the few humanoid companies already in production with 1,000 units planned for 2025. UBTECH has the longest track record in Chinese humanoids, with Walker lineage going back several generations. Their dual hot-swap battery system (48V, 3-5 kWh) is the highest-capacity power system in the industry, though runtime is still limited to 2 hours. At $80K they sit in the mid-range - affordable enough for Chinese government procurement but expensive enough to fund real R&D. Listed in Hong Kong as UBXG.HK.',
-    ticker: 'UBXG.HK',
+    description: 'One of the few humanoid companies already in production with 1,000 units planned for 2025. UBTECH has the longest track record in Chinese humanoids, with Walker lineage going back several generations. Their dual hot-swap battery system (48V, 3-5 kWh) is the highest-capacity power system in the industry, though runtime is still limited to 2 hours. At $80K they sit in the mid-range - affordable enough for Chinese government procurement but expensive enough to fund real R&D. Listed in Hong Kong as 9880.HK since December 2023.',
+    ticker: '9880.HK',
     plyModel: '/models/skeleton.ply',
     robotImage: '/models/robo14_ubtech.webp',
     robotSpecs: {


### PR DESCRIPTION
## Summary

UBTECH Robotics' actual Hong Kong stock code is **9880.HK**, not UBXG.HK.

- UBTECH (优必选) listed on HKEX main board on 2023-12-29 under stock code **9880**.
- `UBXG` is an unrelated NASDAQ ticker (U Power Limited), a Chinese EV charging company. The two companies are entirely separate.

The existing entry's description even says "Listed in Hong Kong as UBXG.HK" — which is incorrect on its own terms, since UBXG is a US exchange ticker and would never carry a `.HK` suffix.

## Verification

- HKEX official quote page: https://www.hkex.com.hk/Market-Data/Securities-Prices/Equities/Equities-Quote?sym=9880
- Bloomberg: https://www.bloomberg.com/quote/9880:HK
- Yahoo Finance: https://finance.yahoo.com/quote/9880.HK/

## Change

- \`src/data/companies.ts\`: updated \`ticker\` field and description mention for the \`ubtech\` entry.

## Test plan

- [x] Ticker field matches HKEX listing
- [x] Description no longer references the wrong ticker
- [ ] Build/lint (please run locally — I don't have the toolchain set up)